### PR TITLE
fix: change deprecated --app flag to use --project

### DIFF
--- a/docs/angular/guides/misc-upgrade.md
+++ b/docs/angular/guides/misc-upgrade.md
@@ -9,7 +9,7 @@ NgUpgrade is a library put together by the Angular team, which we can use in our
 Setting up an Upgrade Module manually involves several steps and is easy to misconfigure. **Nx** provides a command that does it for you.
 
 ```console
-ng g @nrwl/angular:upgrade-module legacyApp --app=myapp
+ng g @nrwl/angular:upgrade-module legacyApp --project=myapp
 ```
 
 This will add and set up `UpgradeModule`, configure `legacyApp`, and will add all the needed dependencies to `package.json`.
@@ -51,7 +51,7 @@ For finer grain control over application performance during conversion to Angula
 Setting up a Downgrade Module manually involves several steps and is easy to misconfigure. **Nx** provides a command that does it for you.
 
 ```console
-ng @nrwl/angular:downgrade-module legacyApp --app=myapp
+ng @nrwl/angular:downgrade-module legacyApp --project=myapp
 ```
 
 This will configure the `AppModule` to not bootstrap the `AppComponent` and instead set it up as an entry component. It will also configure `main.ts` to bootstrap AngularJS and use the `downgradeModule` to downgrade the Angular `AppModule` to run in AngularJS.


### PR DESCRIPTION
`--app=<app_name>` has been deprecated. Changed for `--project=<app_name>`

_[Please make sure you have read the submission guidelines before posting an PR](https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#submit-pr)_

> _Please make sure that your commit message follows our format._

> Example: `fix(nx): must begin with lowercase`

## Current Behavior (This is the behavior we have today, before the PR is merged)

## Expected Behavior (This is the new behavior we can expect after the PR is merged)

## Issue
